### PR TITLE
Build button source code change to match new org name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # soingest
 
-[![Build Status](https://travis-ci.org/ibm-cds-labs/soingest.svg?branch=master)](https://travis-ci.org/ibm-cds-labs/soingest)
+[![Build Status](https://travis-ci.org/ibm-watson-data-lab/soingest.svg?branch=master)](https://travis-ci.org/ibm-watson-data-lab/soingest)
 
 A Stack Overflow data ingest tool written for OpenWhisk.
 


### PR DESCRIPTION
Minor tweak - the travis build buttons are broken after the github org was renamed.  This just puts in the new button code.