### PR TITLE
Bot notifications

### DIFF
--- a/notifier/notifier.js
+++ b/notifier/notifier.js
@@ -35,7 +35,7 @@ function main(data) {
       }
 
       if(send_to_hubot) {
-        var hardcoded_hubot_url = "http://a5a9640a.ngrok.io" + "/hubot/stackoverflow/incoming";
+        var hardcoded_hubot_url = "http://sobot.mybluemix.net" + "/hubot/stackoverflow/incoming";
         var event = {
           type: "new-question",
           data: data,

--- a/notifier/notifier.js
+++ b/notifier/notifier.js
@@ -2,31 +2,37 @@ function main(data) {
   return new Promise(function(resolve, reject) {
     var request = require('request');
 
-    if(data.status == 'new') {
-      var message = "New question: <" + data.question.link + "|" + data.question.title + "> (tagged: " + data.question.tags + ")";
-      console.log(message);
+    // primitive feature toggles to transition between notification types
+    var send_to_slack = true;
+    var send_to_hubot = true;
 
-      var options = {
+    if(data.status == 'new') {
+      if(send_to_slack) {
+        var message = "New question: <" + data.question.link + "|" + data.question.title + "> (tagged: " + data.question.tags + ")";
+        console.log(message);
+
+        var options = {
           "text": message,
           "icon_emoji": ":postit:"
-      };
+        };
 
-      request({
-        url: data.slackURL,
-        method: "POST",
-        headers: {"Content-Type": "application/json"},
-        body: JSON.stringify(options)
-      }, function (err, response, body) {
-        if(err) {
-          console.log(err);
-          reject ({payload: "Failed"});
-        } else {
-          console.log("Status: " + response.statusCode);
-          console.log("Response Body: " + body);
-          resolve( {payload: "Notified"} );
-        }
-      });
+        request({
+          url: data.slackURL,
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(options)
+        }, function (err, response, body) {
+          if(err) {
+            console.log(err);
+            reject ({payload: "Failed"});
+          } else {
+            console.log("Status: " + response.statusCode);
+            console.log("Response Body: " + body);
+            resolve( {payload: "Notified"} );
+          }
+        });
 
+      }
     } else {
       resolve( {payload: "Complete"} );
     }

--- a/notifier/notifier.js
+++ b/notifier/notifier.js
@@ -33,6 +33,31 @@ function main(data) {
         });
 
       }
+
+      if(send_to_hubot) {
+        var hardcoded_hubot_url = "http://a5a9640a.ngrok.io" + "/hubot/stackoverflow/incoming";
+        var event = {
+          type: "new-question",
+          data: data,
+          a: 22
+        };
+
+        request({
+          url: hardcoded_hubot_url,
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(event)
+        }, function (err, response, body) {
+          if(err) {
+            console.log(err);
+            reject ({payload: "Failed"});
+          } else {
+            console.log("Status: " + response.statusCode);
+            console.log("Response Body: " + body);
+            resolve( {payload: "Notified"} );
+          }
+        });
+      }
     } else {
       resolve( {payload: "Complete"} );
     }


### PR DESCRIPTION
This patch will enable _additional_ notifications - as well as our existing slack notifications, it will send webhooks to a slackbot (currently deployed in my space while we decide if we like it) which will notify into the `#advo-stack-overflow-t` slack channel.  Accepting this change shouldn't affect anything we already have, but will wire in the next generation notifications so we can see them working and maybe make changes.