### PR TITLE
[WIP] Respond to new question assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,20 @@ It consists of the following OpenWhisk actions (all of them in the `stackoverflo
 
 **Quick Start** run `./deploy.sh` and check that the `cloudantURL`, `slackURL`, and `dbname` parameters are set on the `stackoverflow` package (optional: also set the `apikey` parameter to a valid StackOverflow API key).  Then invoke `stackoverflow/socron` with your desired `tags` param.  To set the setup configured rules so that the actions run periodically, run `./rules.sh`.
 
+## Deployment
+
 To deploy to IBM Cloud, there are [TravisCI setup instructions on the wiki](https://github.com/ibm-watson-data-lab/soingest/wiki/TravisCI-setup).
+
+## Development Setup
+
+Look at `rules.sh` and `deploy.sh` - these are set up by default for Travis, so make some changes to use this stuff locally but do not commit your changes to git unless there's something we need to change on our central deploy.  Try this:
+ - remove the first half of `deploy.sh` so that we're not checking for env vars or installing `bx`
+ - update all the commands to use `bx` instead of a path to Bluemix_CLI
+
+Make sure your local `bx` tool is targetting your preferred org and workspace (since this is Cloud Functions, they don't run locally)
+
+Configure environment variables, you will need at least:
+ - `CLOUDANT_URL` to point to the URL (including creds) of the cloudant to use
+ - `QUESTIONS_DB` usually "questions"
+ - `BOT_URL` either the publicly-running bot (if you're not working on the bot) or the URL (try using ngrok) to the bot running on your local machine
+

--- a/db-listener/db-listener.js
+++ b/db-listener/db-listener.js
@@ -1,0 +1,40 @@
+function main(data) {
+
+  if(data._id) {
+    console.log("An issue was assigned to " + data.assigned_to_name);
+    return new Promise(function (resolve, reject) {
+      var request = require('request');
+      var bot_url = data.botURL + "/stackoverflow/event";
+      var event = {
+        type: data.type,
+        data: {
+            assigned_to: data.assigned_to,
+            assigned_to_name: data.assigned_to_name,
+            assigned_by: data.assigned_by,
+            assigned_by_name: data.assigned_by_name,
+            question_id: data.question_id,
+            title: data.title
+        }
+      };
+
+      request({
+        url: bot_url,
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(event)
+      }, function (err, response, body) {
+        if(err) {
+          console.log(err);
+          reject ({payload: "Failed"});
+        } else {
+          console.log("Status: " + response.statusCode);
+          console.log("Response Body: " + body);
+          resolve( {payload: "Notified"} );
+        }
+      });
+
+    });
+  } else {
+    console.log("No document received");
+  }
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -44,8 +44,12 @@ set -x
 
 
 # actions for store and notify, and a sequence for those
-
 ./Bluemix_CLI/bin/bluemix wsk action update $WSK_PACKAGE/storer storer/storer.js
 ./Bluemix_CLI/bin/bluemix wsk action update $WSK_PACKAGE/notifier notifier/notifier.js
 
 ./Bluemix_CLI/bin/bluemix wsk action update $WSK_PACKAGE/qhandler --sequence $WSK_PACKAGE/storer,$WSK_PACKAGE/notifier
+
+# handle Cloudant changes actions - use the built-in cloudant READ action
+./Bluemix_CLI/bin/bluemix wsk action update $WSK_PACKAGE/db-listener db-listener/db-listener.js
+
+./Bluemix_CLI/bin/bluemix wsk action update $WSK_PACKAGE/db-doc-handler --sequence /Lorna.Mitchell_dev/Bluemix_Lorna-Cloudant_Credentials-1/read,$WSK_PACKAGE/db-listener

--- a/rules.sh
+++ b/rules.sh
@@ -27,3 +27,10 @@
 ./Bluemix_CLI/bin/bluemix wsk rule update so_jupyterrule so_jupyter $WSK_PACKAGE/socron
 ./Bluemix_CLI/bin/bluemix wsk rule enable so_jupyterrule
 
+# watch events db changes feed
+./Bluemix_CLI/bin/bluemix wsk trigger delete so_dbchanges
+./Bluemix_CLI/bin/bluemix wsk trigger create so_dbchanges --feed /Lorna.Mitchell_dev/Bluemix_Lorna-Cloudant_Credentials-1/changes --param dbname events
+
+./Bluemix_CLI/bin/bluemix wsk rule update so_dbrule so_dbchanges $WSK_PACKAGE/db-doc-handler
+./Bluemix_CLI/bin/bluemix wsk rule enable so_dbrule
+


### PR DESCRIPTION
When a question is assigned, a new document should appear in the "events" database.  This creates an openwhisk sequence to react to the new document and notify the bot that this happened.

Marked as "WIP" while I work out how to work around the requirement for hardcoded package names in the trigger setup :/